### PR TITLE
Fix: Discord client messages sending doubles+ whenever plugin becomes reloaded

### DIFF
--- a/FishingTalk.cs
+++ b/FishingTalk.cs
@@ -152,7 +152,16 @@ namespace FishingTalk
             WebhookRequest json = JsonConvert.DeserializeObject<WebhookRequest>(request);
             return json;
         }
+
+        public override void onEnd()
+        {
+            base.onEnd();
+
+            // these statements are needed to allow for the plugin to be reloaded!
+            _discordBot.Stop();
+        }
     }
+
     public class DiscordBot
     {
         private DiscordSocketClient _client;
@@ -497,6 +506,14 @@ namespace FishingTalk
 
             _plugin.SendWebfishMessage(authorUsername, message.Content);
         }
-    
+
+        public void Stop()
+        {
+            if (_client != null)
+            {
+                _client.LogoutAsync();
+                _client.StopAsync();
+            }
+        }
     }
 }


### PR DESCRIPTION
After `!reload`ing, FishingTalk will seemingly create another client which unexpectedly results in channel messages being relayed twice. ( I didn't try more than one reload but presumably this would happen each time?)

<img width="660" height="332" alt="image" src="https://github.com/user-attachments/assets/01559734-a895-485d-a63a-b6d66b6645e9" />


I think this small change _should_ resolve it but don't take my word for it 😅  especially since they are async calls.
Most plugins need to do some special handling in `onEnd` to accommodate re-initialization- like, unregistering commands, but Cove lets you do as much or as little as you want to...